### PR TITLE
tweak colour and sizing of W3C logo for "W3C Workshop" post (on homepage and post page)

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -421,8 +421,8 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 }
 
 .post-card-excerpt p:after {
-  content: "\00a0…";
-  opacity: .5;
+    content: "\00a0…";
+    opacity: .5;
 }
 
 .post-card-meta {
@@ -1969,4 +1969,36 @@ a.assets-link:hover {
 .table-cell {
     display: table-cell;
     vertical-align: middle;
+}
+
+/* Homepage */
+.post-card-image-link[href$="webvr-api-transitions-to-w3c-standard/"] .post-card-image {
+    background-color: #fff;
+    background-size: 200px auto;
+}
+/* Post page: https://blog.mozvr.com/webvr-api-transitions-to-w3c-standard/ */
+.post-card-image-link[href$="webvr-api-transitions-to-w3c-standard/"] .post-full-image {
+    background-color: #fff;
+    height: 18rem;
+    object-fit: contain;
+}
+
+/* Homepage */
+.post-card-image-link[href$="firefox-reality-bringing-the-immersive-web-to-mixed-reality-headsets/"] .post-card-image {
+    background-color: #b8cfff;  /* Colour lightened from background colour used in masthead here: https://blog.mozilla.org/blog/2018/04/03/mozilla-brings-firefox-augmented-virtual-reality/ */
+    background-size: 90% auto;
+}
+/* Post page: https://blog.mozvr.com/firefox-reality-bringing-the-immersive-web-to-mixed-reality-headsets/ */
+.post-card-image-link[href$="firefox-reality-bringing-the-immersive-web-to-mixed-reality-headsets/"] .post-full-image {
+    height: 14rem;
+    object-fit: contain;
+}
+
+.post-full-content img,
+.post-full-content video {
+    max-width: 840px;
+}
+
+.post-full-content h2 {
+    margin-bottom: .75rem;
 }


### PR DESCRIPTION
fixes this:

<img width="876" alt="screen shot 2017-12-08 at 4 12 03 am" src="https://user-images.githubusercontent.com/203725/33758834-018ccfbe-dbce-11e7-9331-496b8cba89dd.png">

<img width="439" alt="screen shot 2017-12-08 at 4 11 57 am" src="https://user-images.githubusercontent.com/203725/33758835-01a2deb2-dbce-11e7-826f-b9244bd41cff.png">

to this:

<img width="871" alt="screen shot 2017-12-08 at 4 15 02 am" src="https://user-images.githubusercontent.com/203725/33758948-70592f28-dbce-11e7-807d-acbccd979395.png">

<img width="344" alt="screen shot 2017-12-08 at 4 15 22 am" src="https://user-images.githubusercontent.com/203725/33758947-7048ab62-dbce-11e7-81a8-610cf3cde6e7.png">

<hr>

for now, as a temporary workaround, I've added the styles to the `ghost_head` in the [`Settings > Code Injection` page](https://mozvr.ghost.io/ghost/settings/code-injection/).
